### PR TITLE
CytoscapePing() in all workflows

### DIFF
--- a/workflows/PancCanNet-workflow1.Rmd
+++ b/workflows/PancCanNet-workflow1.Rmd
@@ -107,6 +107,11 @@ Lighter areas in the heatmap show pathways with similar gene content (high simil
 
 For the next step, please make sure that you have Cytoscape v3.8.0+ running. We want to explore the cross-talk between the pathway and see which central genes are present in many different pathways.
 
+```{r}
+RCy3::cytoscapePing()
+
+```
+
 ```{r collection network}
 # create pathway-gene network
 graph <- igraph::graph_from_edgelist(as.matrix(pwy.genes), directed = TRUE)

--- a/workflows/PancCanNet-workflow1.Rmd
+++ b/workflows/PancCanNet-workflow1.Rmd
@@ -306,6 +306,9 @@ You can now explore the gene expression changes in the PancCanNet pathways. (blu
 ```{r session}
 cys.file <- file.path(getwd(), "output/workflow1.cys")
 saveSession(cys.file) 
+
+# comment following line if you want to manipulate the visualization in Cytoscape
+RCy3::closeSession(save.before.closing = F)
 ```
 
 ## Clear environment

--- a/workflows/PancCanNet-workflow2.Rmd
+++ b/workflows/PancCanNet-workflow2.Rmd
@@ -344,7 +344,10 @@ p <- "WP2877"
 
 ```{r session}
 cys.file <- file.path(getwd(), "output/workflow2.cys")
-saveSession(cys.file) 
+saveSession(cys.file)
+
+# comment following line if you want to manipulate the visualization in Cytoscape
+RCy3::closeSession(save.before.closing = F)
 ```
 
 ## Clear environment

--- a/workflows/PancCanNet-workflow2.Rmd
+++ b/workflows/PancCanNet-workflow2.Rmd
@@ -228,6 +228,11 @@ The genes not present in any pathway are included in the visualization but can b
 Please make sure you have Cytoscape opened before you run this code!
 
 ```{r}
+RCy3::cytoscapePing()
+
+```
+
+```{r}
 pwy <- unique(ewp.basal.res[,c(1,2)])
 colnames(pwy) <- c("id","label")
 pwy$type <- 'pathway'

--- a/workflows/PancCanNet-workflow3.Rmd
+++ b/workflows/PancCanNet-workflow3.Rmd
@@ -153,11 +153,10 @@ exportImage(png.file,'PNG', zoom = 500)
 
 ```{r}
 # Saving output
-
 cys.file <- file.path(getwd(), "output/workflow3.cys")
 saveSession(cys.file) 
 
-#comment following line if you want to manipulate the visualization in Cytoscape
+# comment following line if you want to manipulate the visualization in Cytoscape
 RCy3::closeSession(save.before.closing = F)
 ```
 

--- a/workflows/PancCanNet-workflow4.Rmd
+++ b/workflows/PancCanNet-workflow4.Rmd
@@ -228,7 +228,10 @@ Drugs are visualized as purple hexagons.
 
 ```{r session}
 cys.file <- file.path(getwd(), "output/workflow4.cys")
-saveSession(cys.file) 
+saveSession(cys.file)
+
+# comment following line if you want to manipulate the visualization in Cytoscape
+RCy3::closeSession(save.before.closing = F)
 ```
 
 ## Clear environment

--- a/workflows/PancCanNet-workflow5.Rmd
+++ b/workflows/PancCanNet-workflow5.Rmd
@@ -178,7 +178,7 @@ wpid2gene.2 <- wpid2gene[(wpid2gene$wpid %in% ht$node)|(wpid2gene$gene %in% ht$n
 graph <- graph_from_edgelist(as.matrix(wpid2gene.2),directed = FALSE)
 
 #check that cytoscape is connected
-cytoscapePing()
+RCy3::cytoscapePing()
 
 # create igraph if not yet available
 net <- RCy3::createNetworkFromIgraph(graph)


### PR DESCRIPTION
Added "cytoscapePing()" in workflows 1 and 2 for consistency (to check whether Cytoscape is active).

Also: In workflow 3 there was a line to close the cytoscape session. I added this to workflows 1,2,4 as well. However, I am not sure if this is desirable everywhere (otherwise delete it from workflow 3).